### PR TITLE
Prevent scrollwheel zooming

### DIFF
--- a/app/assets/javascripts/sites.js.erb
+++ b/app/assets/javascripts/sites.js.erb
@@ -2,7 +2,7 @@
 cloudmade_key = "<%= Acres::Application.config.cloudmade_key %>";
 cloudmade_url = "http://{s}.tile.cloudmade.com/" + cloudmade_key + "/1714/256/{z}/{x}/{y}.png";
 
-map = L.map('map');
+map = L.map('map', { scrollWheelZoom: false });
 showMap(map);
 
 function showMap(map) {


### PR DESCRIPTION
With scrollwheel zooming, it was hard to scroll down the page because the full-width map would capture the scrolling and use it to zoom.  Now it's easier to scroll down.
