### PR TITLE
Bugfix facebook event hanfling.

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -7,7 +7,8 @@ class Event
     coerce :end_time, ->(value) { DateTime.parse(value) }
 
     def times
-      result = self.start_time.strftime("%A, %B %d at %I:%M%p")
+      result = ''
+      result = self.start_time.strftime("%A, %B %d at %I:%M%p") unless self.start_time.blank?
       result += self.end_time.strftime(" - %I:%M%p") unless self.end_time.blank? 
     end
   end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -37,18 +37,24 @@ class Event
   end
 
   def self.build_events(id, name, url)
-    event_objects = []
-    events = get_facebook_events(id)
-    # pp events
-    if !events.nil?
-      events.each do |event|
-        break if event['id'].blank?
-        event = add_site_data(event, name, url)
-        # Convert hash to an Event object and add to @events array.
-        event_objects << hash_to_object(event)
+    begin
+      event_objects = []
+      events = get_facebook_events(id)
+      # pp events
+      if !events.nil?
+        events.each do |event|
+          next if event['id'].blank?
+          event = add_site_data(event, name, url)
+          # Convert hash to an Event object and add to @events array.
+          event_objects << hash_to_object(event)
+        end
       end
+      event_objects
+    rescue
+      # Catch facebook errors, and return an empty array. 
+      # TODO alert bugsnag or something to monitor fb hit failures.
+      []
     end
-    event_objects
   end
 
   def self.add_site_data(event, name, url)

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -3,8 +3,8 @@ require 'pp'
 class Event
 
   class EventObject < Dish::Plate
-    coerce :start_time, ->(value) { DateTime.parse(value) }
-    coerce :end_time, ->(value) { DateTime.parse(value) }
+    coerce :start_time, ->(value) { value.blank? ? '' : DateTime.parse(value) }
+    coerce :end_time, ->(value) { value.blank? ? '' : DateTime.parse(value) }
 
     def times
       result = ''
@@ -26,7 +26,7 @@ class Event
   end
 
   def self.get_facebook_events(id)
-    @graph.get_connection(id, "events", { fields: 'id, name, cover, place, description, end_time' })
+    @graph.get_connection(id, "events", { fields: 'id, name, cover, description, end_time' })
   end
 
   private 
@@ -42,6 +42,7 @@ class Event
     # pp events
     if !events.nil?
       events.each do |event|
+        break if event['id'].blank?
         event = add_site_data(event, name, url)
         # Convert hash to an Event object and add to @events array.
         event_objects << hash_to_object(event)

--- a/app/views/events/index.html.haml
+++ b/app/views/events/index.html.haml
@@ -9,11 +9,11 @@
           -if !event.cover.blank?
             = image_tag event.cover.source
         .col-sm-9
-          %h3
-            -if !event.name.blank?
+          -if !event.name.blank?
+            %h3
               = link_to event.name, "http://facebook.com/events/#{event.id}", :target => "_blank"
-          %h4
-            -if !event.site.blank?
+          -if !event.site.blank?
+            %h4
               %a{ href: event.site.url }
                 = event.site.name 
           %p

--- a/app/views/events/index.html.haml
+++ b/app/views/events/index.html.haml
@@ -10,7 +10,8 @@
             = image_tag event.cover.source
         .col-sm-9
           %h3
-            = link_to event.name, "http://facebook.com/events/#{event.id}", :target => "_blank"
+            -if !event.name.blank?
+              = link_to event.name, "http://facebook.com/events/#{event.id}", :target => "_blank"
           %h4
             -if !event.site.blank?
               %a{ href: event.site.url }

--- a/app/views/events/index.html.haml
+++ b/app/views/events/index.html.haml
@@ -6,20 +6,24 @@
       -# = event.inspect
       .row
         .col-sm-3
-          = image_tag event.cover.source
+          -if !event.cover.blank?
+            = image_tag event.cover.source
         .col-sm-9
           %h3
             = link_to event.name, "http://facebook.com/events/#{event.id}", :target => "_blank"
           %h4
-            %a{ href: event.site.url }
-              = event.site.name 
+            -if !event.site.blank?
+              %a{ href: event.site.url }
+                = event.site.name 
           %p
             %em
               = event.times
-          %p 
-            = event.description
-          %p
-            %strong
-              = event.place.name + " - "
-              = event.place.location.street
-              = event.place.location.city
+          -if !event.description.blank?
+            %p 
+              = event.description
+          -if !event.place.blank?
+            %p
+              %strong
+                = event.place.name + " - "
+                = event.place.location.street
+                = event.place.location.city

--- a/spec/features/events_spec.rb
+++ b/spec/features/events_spec.rb
@@ -3,6 +3,8 @@ require 'pp'
 
 USER_EVENT = FactoryGirl.build(:event, name: 'First event!', id: 11, start_time: "2015-01-01T14:30:00+1000", end_time: "2015-01-01T16:00:00+1000")
 ACRES_EVENT = FactoryGirl.build(:event, name: 'Acres foo event', id: 22, start_time: "2015-02-01T14:30:00+1000", end_time: "2015-02-01T16:00:00+1000")
+EMPTY_EVENT = { "id" => 33, "name" => "Empty event" }
+NIL_EVENT = {}
 
 feature "events" do
   include UIHelper
@@ -10,15 +12,17 @@ feature "events" do
   context "sites" do
     before(:each) do
       Event.stub(:get_facebook_events) do |id|
-        pp id
         case id
         when 1
           [ USER_EVENT ]
         when 2
           [ ACRES_EVENT ]
+        when 3
+          [ EMPTY_EVENT ]
+        when 4
+          [ NIL_EVENT ]
         end
       end
-
       Site.any_instance.stub(:get_facebook_page) do |site,url|  
         id = url.scan(/\d/).first
         id.nil? ? { 'id' => url } : { 'id' => id, 'name' => 'foo' }
@@ -33,7 +37,7 @@ feature "events" do
       click_button 'Create Site'
       user_event_obj = Event.hash_to_object(Event.add_site_data(USER_EVENT, Site.last.to_s, site_path(Site.last)))
       visit '/events'
-      expect(page.find('//h1.title')).to have_content 'Event'
+      expect(page.find('//h1.title')).to have_content 'Events'
       expect(page).to have_content 'First event!'
       expect(page).to have_content "Some Community Garden"
       expect(page).to have_content "Brunswick"
@@ -45,6 +49,9 @@ feature "events" do
     end
 
     scenario "user should see acres facebook events" do
+      setup_site
+      fill_in 'Facebook', :with => 'http://facebook.com/acres1'
+      click_button 'Create Site'
       Figaro.env.stub(:acres_fb_id).and_return(2)
       Figaro.env.stub(:acres_site_name).and_return("acres")
       Figaro.env.stub(:acres_host).and_return("http://www.acres.org")
@@ -52,6 +59,24 @@ feature "events" do
       visit '/events'
       expect(page).to have_content 'Acres foo event'
       expect(page).to have_content acres_event_obj.times
+    end
+
+    scenario "page should handle events missing any fields" do
+      setup_site
+      fill_in 'Facebook', :with => 'http://facebook.com/acres3'
+      click_button 'Create Site'
+      user_event_obj = Event.hash_to_object(Event.add_site_data(EMPTY_EVENT, nil, nil))
+      visit '/events'
+      expect(page).to have_content 'Empty event'
+    end
+
+    scenario "page should handle nil events" do
+      setup_site
+      fill_in 'Facebook', :with => 'http://facebook.com/acres4'
+      click_button 'Create Site'
+      user_event_obj = Event.hash_to_object(Event.add_site_data(NIL_EVENT, nil, nil))
+      visit '/events'
+      expect(page.find('//h1.title')).to have_content 'Events'
     end
   end
 end


### PR DESCRIPTION
Check all facebook event values for blankness - seems it may happen to any of them, and remove place as this can be private and unhelpfully throw an error, returning nothing.